### PR TITLE
Added reaction based interface for atsub participation

### DIFF
--- a/Utilities.py
+++ b/Utilities.py
@@ -1,0 +1,13 @@
+import discord
+
+def retrieve_embed_field_index(field_name: str, embed: discord.Embed):
+    """
+    Retrieves the index of a embed field, or -1 if it doesn't exist.
+    :param field_name: str
+    :param embed: discord.Embed
+    :return: int
+    """
+    for i, field in enumerate(embed.fields):
+        if field.name == field_name:
+            return i
+    return -1

--- a/bot.py
+++ b/bot.py
@@ -11,7 +11,10 @@ import config
 with open('./token') as token_file:
     token = token_file.readline()
 
-client = commands.Bot(command_prefix=config.PREFIX, help_command=PrettyHelp())
+intents = discord.Intents.default()
+intents.members = True
+intents.reactions = True
+client = commands.Bot(command_prefix=config.PREFIX, help_command=PrettyHelp(), intents=intents)
 
 
 # Gives debug feedback that the bot has successfully launched.


### PR DESCRIPTION
# Changes

- Automatically add ✅ and ❌ reactions to an `atsub` message
- Add a field to the `atsub` embed: `Going` that displays all members that have reacted with ✅
- Update the `Going` field whenever someone reacts/unreacts to ✅
- Update intents
- Update subscriptions usage messages

# Tests 
Adding and removing reactions to BananaTesting's messages. Thorough testing may be required.